### PR TITLE
Closes #5. Changed Copyright Party.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 IPFS Shipyard
+Copyright (c) 2018 Protocol Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Simple change to make Protocol Labs the copyright holder.